### PR TITLE
Fix undefined variable usage.

### DIFF
--- a/deploy/fnDeploy.js
+++ b/deploy/fnDeploy.js
@@ -238,7 +238,7 @@ class FNDeploy {
         if (!fname.includes('/')) {
 		// then we'll prefix FN_REGISTRY
             let reg = process.env.FN_REGISTRY;
-            if (reg !== '') {
+            if (reg !== undefined && reg !== '') {
                 if (!reg.endsWith('/')) {
                     reg += '/';
                 }


### PR DESCRIPTION
If fname doesn't contain a /, and if the FN_REGISTRY environment variable isn't defined, then the condition will be true, because `undefined !== ''`, and then we try to call `reg.endsWith` on `undefined`. This PR fixes this.