### PR TITLE
Fixing chaining of commands.

### DIFF
--- a/deploy/fnDeploy.js
+++ b/deploy/fnDeploy.js
@@ -229,7 +229,7 @@ class FNDeploy {
             this.dockerBuild.bind(this),
             this.postBuild,
         ];
-        return BB.mapSeries(steps, (s) => { s(func); })
+        return BB.mapSeries(steps, (s) => s(func))
             .finally(this.cleanup(func.dockerFile));
     }
 


### PR DESCRIPTION
By writing `{ s(func) }` instead of `s(func)`, the return value of each individual build step is being ignored, and if one step in the chain failed, the whole deployment would still continue anyway, instead of the error being caught and displayed properly.